### PR TITLE
Feat/optional return type

### DIFF
--- a/SlottyMedia.Database/DatabaseActions.cs
+++ b/SlottyMedia.Database/DatabaseActions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq.Expressions;
 using SlottyMedia.Database.Exceptions;
+using SlottyMedia.Utils;
 using Supabase.Postgrest;
 using Supabase.Postgrest.Models;
 using Client = Supabase.Client;
@@ -187,45 +188,49 @@ public class DatabaseActions : IDatabaseActions
     ///     Thrown when a network error, argument null, invalid operation, timeout, task
     ///     cancellation, or unexpected error occurs.
     /// </exception>
-    public virtual async Task<T> GetEntityByField<T>(string field, string value) where T : BaseModel, new()
+    public virtual Task<Optional<T>> GetEntityByField<T>(string field, string value) where T : BaseModel, new()
     {
-        try
+        return Optional<T>.OfAsync(async () =>
         {
-            var result = await _supabaseClient.From<T>().Filter(field, Constants.Operator.Equals, value).Single();
-            if (result is null)
-                throw new DatabaseMissingItemException(
-                    $"The Entity with the Value {value} in the Field {field} in the " +
-                    $"Table {typeof(T)} could not be found in the database.");
-            return result;
-        }
-        catch (DatabaseMissingItemException)
-        {
-            throw;
-        }
-        catch (HttpRequestException ex)
-        {
-            throw new GeneralDatabaseException("A network error occurred while retrieving the entity.", ex);
-        }
-        catch (ArgumentNullException ex)
-        {
-            throw new GeneralDatabaseException("A required argument was null while retrieving the entity.", ex);
-        }
-        catch (InvalidOperationException ex)
-        {
-            throw new GeneralDatabaseException("An invalid operation occurred while retrieving the entity.", ex);
-        }
-        catch (TimeoutException ex)
-        {
-            throw new GeneralDatabaseException("A timeout occurred while retrieving the entity.", ex);
-        }
-        catch (TaskCanceledException ex)
-        {
-            throw new GeneralDatabaseException("The task was canceled while retrieving the entity.", ex);
-        }
-        catch (Exception ex)
-        {
-            throw new GeneralDatabaseException("An unexpected error occurred while retrieving the entity.", ex);
-        }
+            try
+            {
+                var result = await _supabaseClient.From<T>().Filter(field, Constants.Operator.Equals, value).Single();
+                if (result is null)
+                    throw new DatabaseMissingItemException(
+                        $"The Entity with the Value {value} in the Field {field} in the " +
+                        $"Table {typeof(T)} could not be found in the database.");
+                return result;
+            }
+            catch (DatabaseMissingItemException)
+            {
+                throw;
+            }
+            catch (HttpRequestException ex)
+            {
+                throw new GeneralDatabaseException("A network error occurred while retrieving the entity.", ex);
+            }
+            catch (ArgumentNullException ex)
+            {
+                throw new GeneralDatabaseException("A required argument was null while retrieving the entity.", ex);
+            }
+            catch (InvalidOperationException ex)
+            {
+                throw new GeneralDatabaseException("An invalid operation occurred while retrieving the entity.", ex);
+            }
+            catch (TimeoutException ex)
+            {
+                throw new GeneralDatabaseException("A timeout occurred while retrieving the entity.", ex);
+            }
+            catch (TaskCanceledException ex)
+            {
+                throw new GeneralDatabaseException("The task was canceled while retrieving the entity.", ex);
+            }
+            catch (Exception ex)
+            {
+                throw new GeneralDatabaseException("An unexpected error occurred while retrieving the entity.", ex);
+            }
+        });
+        
     }
 
     /// <summary>
@@ -241,45 +246,48 @@ public class DatabaseActions : IDatabaseActions
     ///     Thrown when a network error, argument null, invalid operation, timeout, task
     ///     cancellation, or unexpected error occurs.
     /// </exception>
-    public async Task<T> GetEntitieWithSelectorById<T>(Expression<Func<T, object[]>> selector, string field,
+    public Task<Optional<T>> GetEntitieWithSelectorById<T>(Expression<Func<T, object[]>> selector, string field,
         string value) where T : BaseModel, new()
     {
-        try
+        return Optional<T>.OfAsync(async () =>
         {
-            var result = await _supabaseClient.From<T>().Filter(field, Constants.Operator.Equals, value)
-                .Select(selector).Single();
-            if (result is null)
-                throw new DatabaseMissingItemException("The Items could not be retrieved from the database.");
-            return result;
-        }
-        catch (DatabaseMissingItemException)
-        {
-            throw;
-        }
-        catch (HttpRequestException ex)
-        {
-            throw new GeneralDatabaseException("A network error occurred while retrieving the entity.", ex);
-        }
-        catch (ArgumentNullException ex)
-        {
-            throw new GeneralDatabaseException("A required argument was null while retrieving the entity.", ex);
-        }
-        catch (InvalidOperationException ex)
-        {
-            throw new GeneralDatabaseException("An invalid operation occurred while retrieving the entity.", ex);
-        }
-        catch (TimeoutException ex)
-        {
-            throw new GeneralDatabaseException("A timeout occurred while retrieving the entity.", ex);
-        }
-        catch (TaskCanceledException ex)
-        {
-            throw new GeneralDatabaseException("The task was canceled while retrieving the entity.", ex);
-        }
-        catch (Exception ex)
-        {
-            throw new GeneralDatabaseException("An unexpected error occurred while retrieving the entity.", ex);
-        }
+            try
+            {
+                var result = await _supabaseClient.From<T>().Filter(field, Constants.Operator.Equals, value)
+                    .Select(selector).Single();
+                if (result is null)
+                    throw new DatabaseMissingItemException("The Items could not be retrieved from the database.");
+                return result;
+            }
+            catch (DatabaseMissingItemException)
+            {
+                throw;
+            }
+            catch (HttpRequestException ex)
+            {
+                throw new GeneralDatabaseException("A network error occurred while retrieving the entity.", ex);
+            }
+            catch (ArgumentNullException ex)
+            {
+                throw new GeneralDatabaseException("A required argument was null while retrieving the entity.", ex);
+            }
+            catch (InvalidOperationException ex)
+            {
+                throw new GeneralDatabaseException("An invalid operation occurred while retrieving the entity.", ex);
+            }
+            catch (TimeoutException ex)
+            {
+                throw new GeneralDatabaseException("A timeout occurred while retrieving the entity.", ex);
+            }
+            catch (TaskCanceledException ex)
+            {
+                throw new GeneralDatabaseException("The task was canceled while retrieving the entity.", ex);
+            }
+            catch (Exception ex)
+            {
+                throw new GeneralDatabaseException("An unexpected error occurred while retrieving the entity.", ex);
+            }
+        });
     }
 
     /// <summary>

--- a/SlottyMedia.Database/IDatabaseActions.cs
+++ b/SlottyMedia.Database/IDatabaseActions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq.Expressions;
 using SlottyMedia.Database.Exceptions;
+using SlottyMedia.Utils;
 using Supabase.Postgrest;
 using Supabase.Postgrest.Models;
 
@@ -41,7 +42,7 @@ public interface IDatabaseActions
     /// <param name="field">The field to search.</param>
     /// <param name="value">The value to search for.</param>
     /// <returns>Returns the entity from the database.</returns>
-    Task<T> GetEntityByField<T>(string field, string value) where T : BaseModel, new();
+    Task<Optional<T>> GetEntityByField<T>(string field, string value) where T : BaseModel, new();
 
     /// <summary>
     ///     Returns an entity with a selector from the database based on the given field and value.
@@ -51,7 +52,7 @@ public interface IDatabaseActions
     /// <param name="field">The field to search.</param>
     /// <param name="value">The value to search for.</param>
     /// <returns>Returns the entity from the database.</returns>
-    Task<T> GetEntitieWithSelectorById<T>(Expression<Func<T, object[]>> selector, string field, string value)
+    Task<Optional<T>> GetEntitieWithSelectorById<T>(Expression<Func<T, object[]>> selector, string field, string value)
         where T : BaseModel, new();
 
     /// <summary>

--- a/SlottyMedia.Database/SlottyMedia.Database.csproj
+++ b/SlottyMedia.Database/SlottyMedia.Database.csproj
@@ -14,6 +14,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\SlottyMedia.LoggingProvider\SlottyMedia.LoggingProvider.csproj"/>
+        <ProjectReference Include="..\SlottyMedia.Utils\SlottyMedia.Utils.csproj" />
     </ItemGroup>
 
     <Target Name="GenerateDocumentation" AfterTargets="Build;Run" Condition="'$(GITHUB_ACTIONS)' != 'true'">

--- a/SlottyMedia.Tests/Auth/SignUpServiceTest.cs
+++ b/SlottyMedia.Tests/Auth/SignUpServiceTest.cs
@@ -4,6 +4,7 @@ using SlottyMedia.Backend.Services;
 using SlottyMedia.Backend.Services.Interfaces;
 using SlottyMedia.Database;
 using SlottyMedia.Database.Daos;
+using SlottyMedia.Utils;
 using Supabase.Gotrue;
 using Client = Supabase.Client;
 
@@ -86,7 +87,7 @@ public class SignUpServiceTest
 
         var user = new UserDao(Guid.NewGuid(), roleDao.RoleId ?? Guid.Empty, _userName, _email, "TestPassword1!");
 
-        _dbActionMock.Setup(dbAction => dbAction.GetEntityByField<RoleDao>("role", "User")).ReturnsAsync(roleDao);
+        _dbActionMock.Setup(dbAction => dbAction.GetEntityByField<RoleDao>("role", "User")).ReturnsAsync(Optional<RoleDao>.Of(roleDao));
         _dbActionMock.Setup(dbAction =>
             dbAction.Insert(It.Is<UserDao>(u => u.UserName == _userName && u.Email == _email))).ReturnsAsync(user);
 

--- a/SlottyMedia.Tests/DatabaseTests/DatabaseActionTests.cs
+++ b/SlottyMedia.Tests/DatabaseTests/DatabaseActionTests.cs
@@ -184,10 +184,13 @@ public class DatabaseActionTests : BaseDatabaseTestClass
     ///     Tests the GetEntityByField method of DatabaseActions for failure.
     /// </summary>
     [Test]
-    public void GetEntityByField_Failure()
+    public async Task GetEntityByField_Failure()
     {
-        Assert.ThrowsAsync<GeneralDatabaseException>(async () =>
-            await DatabaseActions.GetEntityByField<UserDao>("userID", "invalid-id"));
+        var optional = await DatabaseActions.GetEntityByField<UserDao>("userID", "invalid-id");
+        Assert.Throws<GeneralDatabaseException>(() =>
+        {
+            optional.OrElseThrow();
+        });
     }
 
     /// <summary>
@@ -232,11 +235,14 @@ public class DatabaseActionTests : BaseDatabaseTestClass
     ///     Tests the GetEntitieWithSelectorById method of DatabaseActions for failure.
     /// </summary>
     [Test]
-    public void GetEntitieWithSelectorById_Failure()
+    public async Task GetEntitieWithSelectorById_Failure()
     {
         Expression<Func<UserDao, object[]>> selector = u => new object[] { u.UserId!, u.UserName!, u.Description! };
-        Assert.ThrowsAsync<GeneralDatabaseException>(async () =>
-            await DatabaseActions.GetEntitieWithSelectorById(selector, "userID", "invalid-id"));
+        var optional = await DatabaseActions.GetEntitieWithSelectorById(selector, "userID", "invalid-id");
+        Assert.Throws<GeneralDatabaseException>(() =>
+        {
+            optional.OrElseThrow();
+        });
     }
 
     /// <summary>

--- a/SlottyMedia.Tests/DatabaseTests/DatabaseActionTests.cs
+++ b/SlottyMedia.Tests/DatabaseTests/DatabaseActionTests.cs
@@ -23,8 +23,8 @@ public class DatabaseActionTests : BaseDatabaseTestClass
         {
             if (_userToWorkWith.UserId is null) return;
 
-            var user = await DatabaseActions.GetEntityByField<UserDao>("userID",
-                _userToWorkWith.UserId.ToString() ?? "");
+            var user = (await DatabaseActions.GetEntityByField<UserDao>("userID",
+                _userToWorkWith.UserId.ToString() ?? "")).OrElseThrow();
             if (user != null) await DatabaseActions.Delete(user);
         }
         catch (DatabaseMissingItemException)
@@ -155,7 +155,7 @@ public class DatabaseActionTests : BaseDatabaseTestClass
                 Assert.That(insertedUser.UserId, Is.Not.Null, "Inserted user's UserId should not be null");
             });
 
-            var user = await DatabaseActions.GetEntityByField<UserDao>("userID", insertedUser.UserId.ToString() ?? "");
+            var user = (await DatabaseActions.GetEntityByField<UserDao>("userID", insertedUser.UserId.ToString() ?? "")).OrElseThrow();
             Assert.Multiple(() =>
             {
                 Assert.That(user, Is.Not.Null, "Retrieved user should not be null");
@@ -206,8 +206,8 @@ public class DatabaseActionTests : BaseDatabaseTestClass
             });
 
             Expression<Func<UserDao, object[]>> selector = u => new object[] { u.UserId!, u.UserName!, u.Description! };
-            var user = await DatabaseActions.GetEntitieWithSelectorById(selector, "userID",
-                insertedUser.UserId.ToString() ?? "");
+            var user = (await DatabaseActions.GetEntitieWithSelectorById(selector, "userID",
+                insertedUser.UserId.ToString() ?? "")).OrElseThrow();
             Assert.Multiple(() =>
             {
                 Assert.That(user, Is.Not.Null, "Retrieved user should not be null");

--- a/SlottyMedia.Tests/DatabaseTests/DatabaseModelsTests/CommentDaoTest.cs
+++ b/SlottyMedia.Tests/DatabaseTests/DatabaseModelsTests/CommentDaoTest.cs
@@ -49,8 +49,8 @@ public class CommentDaoTest : BaseDatabaseTestClass
             if (_commentToWorkWith.CommentId is null) return;
 
             var comment =
-                await DatabaseActions.GetEntityByField<CommentDao>("commentID",
-                    _commentToWorkWith.CommentId.ToString() ?? "");
+                (await DatabaseActions.GetEntityByField<CommentDao>("commentID",
+                    _commentToWorkWith.CommentId.ToString() ?? "")).OrElseThrow();
             if (comment != null) await DatabaseActions.Delete(comment);
         }
         catch (DatabaseMissingItemException)
@@ -73,16 +73,16 @@ public class CommentDaoTest : BaseDatabaseTestClass
             if (_postToWorkWith.PostId is null || _forumToWorkWith.ForumId is null ||
                 _userToWorkWith.UserId is null) return;
 
-            var post = await DatabaseActions.GetEntityByField<PostsDao>("postID",
-                _postToWorkWith.PostId.ToString() ?? "");
+            var post = (await DatabaseActions.GetEntityByField<PostsDao>("postID",
+                _postToWorkWith.PostId.ToString() ?? "")).OrElseThrow();
             if (post != null) await DatabaseActions.Delete(post);
 
-            var forum = await DatabaseActions.GetEntityByField<ForumDao>("forumID",
-                _forumToWorkWith.ForumId.ToString() ?? "");
+            var forum = (await DatabaseActions.GetEntityByField<ForumDao>("forumID",
+                _forumToWorkWith.ForumId.ToString() ?? "")).OrElseThrow();
             if (forum != null) await DatabaseActions.Delete(forum);
 
-            var user = await DatabaseActions.GetEntityByField<UserDao>("userID",
-                _userToWorkWith.UserId.ToString() ?? "");
+            var user = (await DatabaseActions.GetEntityByField<UserDao>("userID",
+                _userToWorkWith.UserId.ToString() ?? "")).OrElseThrow();
             if (user != null) await DatabaseActions.Delete(user);
         }
         catch (Exception ex)
@@ -186,8 +186,8 @@ public class CommentDaoTest : BaseDatabaseTestClass
 
 
             var comment =
-                await DatabaseActions.GetEntityByField<CommentDao>("commentID",
-                    insertedComment.CommentId.ToString() ?? "");
+                (await DatabaseActions.GetEntityByField<CommentDao>("commentID",
+                    insertedComment.CommentId.ToString() ?? "")).OrElseThrow();
             Assert.Multiple(() =>
             {
                 Assert.That(comment, Is.Not.Null, "Retrieved comment should not be null");

--- a/SlottyMedia.Tests/DatabaseTests/DatabaseModelsTests/FollowerUserRelationDaoTest.cs
+++ b/SlottyMedia.Tests/DatabaseTests/DatabaseModelsTests/FollowerUserRelationDaoTest.cs
@@ -43,8 +43,8 @@ public class FollowerUserRelationDaoTest : BaseDatabaseTestClass
         {
             if (_relationToWorkWith.FollowerUserRelationId is null) return;
 
-            var relation = await DatabaseActions.GetEntityByField<FollowerUserRelationDao>("followerUserRelationID",
-                _relationToWorkWith.FollowerUserRelationId.ToString() ?? "");
+            var relation = (await DatabaseActions.GetEntityByField<FollowerUserRelationDao>("followerUserRelationID",
+                _relationToWorkWith.FollowerUserRelationId.ToString() ?? "")).OrElseThrow();
             if (relation != null) await DatabaseActions.Delete(relation);
         }
         catch (DatabaseMissingItemException)
@@ -67,11 +67,11 @@ public class FollowerUserRelationDaoTest : BaseDatabaseTestClass
             if (_followerUser.UserId is null || _followedUser.UserId is null) return;
 
             var follower =
-                await DatabaseActions.GetEntityByField<UserDao>("userID", _followerUser.UserId.ToString() ?? "");
+                (await DatabaseActions.GetEntityByField<UserDao>("userID", _followerUser.UserId.ToString() ?? "")).OrElseThrow();
             if (follower != null) await DatabaseActions.Delete(follower);
 
             var followed =
-                await DatabaseActions.GetEntityByField<UserDao>("userID", _followedUser.UserId.ToString() ?? "");
+                (await DatabaseActions.GetEntityByField<UserDao>("userID", _followedUser.UserId.ToString() ?? "")).OrElseThrow();
             if (followed != null) await DatabaseActions.Delete(followed);
         }
         catch (Exception ex)
@@ -146,8 +146,8 @@ public class FollowerUserRelationDaoTest : BaseDatabaseTestClass
                     "Inserted relation should have a FollowerUserRelationId");
             });
 
-            var relation = await DatabaseActions.GetEntityByField<FollowerUserRelationDao>("followerUserRelationID",
-                insertedRelation.FollowerUserRelationId.ToString() ?? "");
+            var relation = (await DatabaseActions.GetEntityByField<FollowerUserRelationDao>("followerUserRelationID",
+                insertedRelation.FollowerUserRelationId.ToString() ?? "")).OrElseThrow();
             Assert.Multiple(() =>
             {
                 Assert.That(relation, Is.Not.Null, "Retrieved relation should not be null");

--- a/SlottyMedia.Tests/DatabaseTests/DatabaseModelsTests/ForumDaoTest.cs
+++ b/SlottyMedia.Tests/DatabaseTests/DatabaseModelsTests/ForumDaoTest.cs
@@ -41,8 +41,8 @@ public class ForumDaoTest : BaseDatabaseTestClass
         {
             if (_forumToWorkWith.ForumId is null) return;
 
-            var forum = await DatabaseActions.GetEntityByField<ForumDao>("forumID",
-                _forumToWorkWith.ForumId.ToString() ?? "");
+            var forum = (await DatabaseActions.GetEntityByField<ForumDao>("forumID",
+                _forumToWorkWith.ForumId.ToString() ?? "")).OrElseThrow();
             if (forum != null) await DatabaseActions.Delete(forum);
         }
         catch (Exception ex)
@@ -61,8 +61,8 @@ public class ForumDaoTest : BaseDatabaseTestClass
         {
             if (_userToWorkWith.UserId is null) return;
 
-            var user = await DatabaseActions.GetEntityByField<UserDao>("userID",
-                _userToWorkWith.UserId.ToString() ?? "");
+            var user = (await DatabaseActions.GetEntityByField<UserDao>("userID",
+                _userToWorkWith.UserId.ToString() ?? "")).OrElseThrow();
             if (user != null) await DatabaseActions.Delete(user);
         }
         catch (DatabaseMissingItemException)
@@ -169,8 +169,8 @@ public class ForumDaoTest : BaseDatabaseTestClass
                 Assert.That(insertedForum.ForumId, Is.Not.Null, "Inserted forum should have a ForumId");
             });
 
-            var forum = await DatabaseActions.GetEntityByField<ForumDao>("forumID",
-                insertedForum.ForumId.ToString() ?? "");
+            var forum = (await DatabaseActions.GetEntityByField<ForumDao>("forumID",
+                insertedForum.ForumId.ToString() ?? "")).OrElseThrow();
             Assert.Multiple(() =>
             {
                 Assert.That(forum, Is.Not.Null, "Retrieved forum should not be null");

--- a/SlottyMedia.Tests/DatabaseTests/DatabaseModelsTests/PostDtoTest.cs
+++ b/SlottyMedia.Tests/DatabaseTests/DatabaseModelsTests/PostDtoTest.cs
@@ -45,8 +45,8 @@ public class PostDtoTest : BaseDatabaseTestClass
         {
             if (_postToWorkWith.PostId is null) return;
 
-            var post = await DatabaseActions.GetEntityByField<PostsDao>("postID",
-                _postToWorkWith.PostId.ToString() ?? "");
+            var post = (await DatabaseActions.GetEntityByField<PostsDao>("postID",
+                _postToWorkWith.PostId.ToString() ?? "")).OrElseThrow();
             if (post != null) await DatabaseActions.Delete(post);
         }
         catch (DatabaseMissingItemException)
@@ -68,12 +68,12 @@ public class PostDtoTest : BaseDatabaseTestClass
         {
             if (_forumToWorkWith.ForumId is null || _userToWorkWith.UserId is null) return;
 
-            var forum = await DatabaseActions.GetEntityByField<ForumDao>("forumID",
-                _forumToWorkWith.ForumId.ToString() ?? "");
+            var forum = (await DatabaseActions.GetEntityByField<ForumDao>("forumID",
+                _forumToWorkWith.ForumId.ToString() ?? "")).OrElseThrow();
             if (forum != null) await DatabaseActions.Delete(forum);
 
-            var user = await DatabaseActions.GetEntityByField<UserDao>("userID",
-                _userToWorkWith.UserId.ToString() ?? "");
+            var user = (await DatabaseActions.GetEntityByField<UserDao>("userID",
+                _userToWorkWith.UserId.ToString() ?? "")).OrElseThrow();
             if (user != null) await DatabaseActions.Delete(user);
         }
         catch (Exception ex)
@@ -175,8 +175,8 @@ public class PostDtoTest : BaseDatabaseTestClass
                 Assert.That(insertedPost.PostId, Is.Not.Null, "Inserted post's PostId should not be null");
             });
 
-            var post = await DatabaseActions.GetEntityByField<PostsDao>("postID",
-                insertedPost.PostId.ToString() ?? string.Empty);
+            var post = (await DatabaseActions.GetEntityByField<PostsDao>("postID",
+                insertedPost.PostId.ToString() ?? string.Empty)).OrElseThrow();
             Assert.Multiple(() =>
             {
                 Assert.That(post, Is.Not.Null, "Retrieved post should not be null");

--- a/SlottyMedia.Tests/DatabaseTests/DatabaseModelsTests/UserLikePostRelationDao.cs
+++ b/SlottyMedia.Tests/DatabaseTests/DatabaseModelsTests/UserLikePostRelationDao.cs
@@ -46,8 +46,8 @@ public class UserLikePostRelationDaoTest : BaseDatabaseTestClass
         {
             if (_relationToWorkWith.UserLikePostRelationId is null) return;
 
-            var relation = await DatabaseActions.GetEntityByField<UserLikePostRelationDao>("userLikePostRelationID",
-                _relationToWorkWith.UserLikePostRelationId.ToString() ?? "");
+            var relation = (await DatabaseActions.GetEntityByField<UserLikePostRelationDao>("userLikePostRelationID",
+                _relationToWorkWith.UserLikePostRelationId.ToString() ?? "")).OrElseThrow();
             if (relation != null) await DatabaseActions.Delete(relation);
         }
         catch (Exception ex)
@@ -67,16 +67,16 @@ public class UserLikePostRelationDaoTest : BaseDatabaseTestClass
             if (_postToWorkWith.PostId is null || _forumToWorkWirh.ForumId is null ||
                 _userToWorkWith.UserId is null) return;
 
-            var post = await DatabaseActions.GetEntityByField<PostsDao>("postID",
-                _postToWorkWith.PostId.ToString() ?? "");
+            var post = (await DatabaseActions.GetEntityByField<PostsDao>("postID",
+                _postToWorkWith.PostId.ToString() ?? "")).OrElseThrow();
             if (post != null) await DatabaseActions.Delete(post);
 
-            var forum = await DatabaseActions.GetEntityByField<ForumDao>("forumID",
-                _forumToWorkWirh.ForumId.ToString() ?? "");
+            var forum = (await DatabaseActions.GetEntityByField<ForumDao>("forumID",
+                _forumToWorkWirh.ForumId.ToString() ?? "")).OrElseThrow();
             if (forum != null) await DatabaseActions.Delete(forum);
 
-            var user = await DatabaseActions.GetEntityByField<UserDao>("userID",
-                _userToWorkWith.UserId.ToString() ?? "");
+            var user = (await DatabaseActions.GetEntityByField<UserDao>("userID",
+                _userToWorkWith.UserId.ToString() ?? "")).OrElseThrow();
             if (user != null) await DatabaseActions.Delete(user);
         }
         catch (DatabaseMissingItemException)
@@ -156,8 +156,8 @@ public class UserLikePostRelationDaoTest : BaseDatabaseTestClass
                     "Inserted relation ID should not be null");
             });
 
-            var relation = await DatabaseActions.GetEntityByField<UserLikePostRelationDao>("userLikePostRelationID",
-                insertedRelation.UserLikePostRelationId.ToString() ?? "");
+            var relation = (await DatabaseActions.GetEntityByField<UserLikePostRelationDao>("userLikePostRelationID",
+                insertedRelation.UserLikePostRelationId.ToString() ?? "")).OrElseThrow();
             Assert.Multiple(() =>
             {
                 Assert.That(relation, Is.Not.Null, "Retrieved relation should not be null");

--- a/SlottyMedia.Tests/ServiceTests/UserServiceTests.cs
+++ b/SlottyMedia.Tests/ServiceTests/UserServiceTests.cs
@@ -8,6 +8,7 @@ using SlottyMedia.Database;
 using SlottyMedia.Database.Daos;
 using SlottyMedia.Database.Exceptions;
 using SlottyMedia.Tests.DatabaseTests;
+using SlottyMedia.Utils;
 
 namespace SlottyMedia.Tests.ServiceTests;
 
@@ -151,7 +152,7 @@ public class UserServiceTests
     {
         var userId = Guid.NewGuid();
         var user = new UserDao { UserId = userId };
-        _mockDatabaseActions.Setup(x => x.GetEntityByField<UserDao>("userID", userId.ToString())).ReturnsAsync(user);
+        _mockDatabaseActions.Setup(x => x.GetEntityByField<UserDao>("userID", userId.ToString())).ReturnsAsync(Optional<UserDao>.Of(user));
 
         var result = await _userService.GetUserById(userId);
 
@@ -252,7 +253,7 @@ public class UserServiceTests
     {
         var userId = Guid.NewGuid();
         var user = new UserDao { UserId = userId, ProfilePic = "123" };
-        _mockDatabaseActions.Setup(x => x.GetEntityByField<UserDao>("userID", userId.ToString())).ReturnsAsync(user);
+        _mockDatabaseActions.Setup(x => x.GetEntityByField<UserDao>("userID", userId.ToString())).ReturnsAsync(Optional<UserDao>.Of(user));
 
         var result = await _userService.GetProfilePic(userId);
 
@@ -306,7 +307,7 @@ public class UserServiceTests
 
         _mockDatabaseActions
             .Setup(x => x.GetEntitieWithSelectorById(It.IsAny<Expression<Func<UserDao, object[]>>>(), "userID",
-                userId.ToString())).ReturnsAsync(user);
+                userId.ToString())).ReturnsAsync(Optional<UserDao>.Of(user));
         _mockPostService
             .Setup(x => x.GetPostsFromForum(userId, 0, 5)).ReturnsAsync(forumName);
 

--- a/SlottyMedia.Tests/SlottyMedia.Tests.csproj
+++ b/SlottyMedia.Tests/SlottyMedia.Tests.csproj
@@ -36,6 +36,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\SlottyMedia.Database\SlottyMedia.Database.csproj"/>
+        <ProjectReference Include="..\SlottyMedia.Utils\SlottyMedia.Utils.csproj" />
         <ProjectReference Include="..\SlottyMedia\SlottyMedia.csproj"/>
     </ItemGroup>
 

--- a/SlottyMedia.Tests/UtilTests/OptionalTests.cs
+++ b/SlottyMedia.Tests/UtilTests/OptionalTests.cs
@@ -20,7 +20,7 @@ public class OptionalTests
     [Test]
     public void Get_WhenInstanceNull_ShouldThrow()
     {
-        var optional = Optional<int?>.Of(() => null);
+        var optional = Optional<int?>.Empty();
         Assert.Throws<NullReferenceException>(() =>
         {
             optional.Get();
@@ -30,7 +30,7 @@ public class OptionalTests
     [Test]
     public void Get_WhenInstancePresent_ShouldReturnInstance()
     {
-        var optional = Optional<int>.Of(() => 7);
+        var optional = Optional<int>.Of(7);
         var value = optional.Get();
         Assert.That(value, Is.EqualTo(7));
     }
@@ -39,7 +39,7 @@ public class OptionalTests
     public void OrElse_WhenCallbackReturns_ShouldReturn()
     {
         var optional = Optional<int>.Of(() => throw new ArithmeticException());
-        var value = optional.OrElse(() => 7);
+        var value = optional.OrElse(7);
         Assert.That(value, Is.EqualTo(7));
     }
 
@@ -51,6 +51,50 @@ public class OptionalTests
         {
             optional.OrElse(() => throw new InvalidDataException());
         });
+    }
+
+    [Test]
+    public void OrElseNull_WhenInstanceNotNull_ShouldReturnInstance()
+    {
+        var optional = Optional<int?>.Of(7);
+        var result = optional.OrElseNull();
+        Assert.That(result, Is.EqualTo(7));
+    }
+    
+    [Test]
+    public void OrElseNull_WhenInstanceNull_ShouldReturnNull()
+    {
+        var optional = Optional<int?>.Empty();
+        var result = optional.OrElseNull();
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void OrElseThrow_WhenEvaluationThrows_ShouldRethrow()
+    {
+        var optional = Optional<int>.Of(() => throw new ArithmeticException());
+        Assert.Throws<ArithmeticException>(() =>
+        {
+            optional.OrElseThrow();
+        });
+    }
+    
+    [Test]
+    public void OrElseThrow_WhenEmpty_ShouldThrow()
+    {
+        var optional = Optional<string>.Empty();
+        Assert.Throws<NullReferenceException>(() =>
+        {
+            optional.OrElseThrow();
+        });
+    }
+    
+    [Test]
+    public void OrElseThrow_WhenInstancePresent_ShouldReturnInstance()
+    {
+        var optional = Optional<string>.Of("Hello");
+        var x = optional.OrElseThrow();
+        Assert.That(x, Is.EqualTo("Hello"));
     }
     
 }

--- a/SlottyMedia.Tests/UtilTests/OptionalTests.cs
+++ b/SlottyMedia.Tests/UtilTests/OptionalTests.cs
@@ -1,0 +1,56 @@
+using SlottyMedia.Utils;
+
+namespace SlottyMedia.Tests.UtilTests;
+
+
+[TestFixture]
+public class OptionalTests
+{
+
+    [Test]
+    public void Get_WhenInnerException_ShouldThrow()
+    {
+        var optional = Optional<int>.Of(() => throw new ArithmeticException());
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            optional.Get();
+        });
+    }
+
+    [Test]
+    public void Get_WhenInstanceNull_ShouldThrow()
+    {
+        var optional = Optional<int?>.Of(() => null);
+        Assert.Throws<NullReferenceException>(() =>
+        {
+            optional.Get();
+        });
+    }
+
+    [Test]
+    public void Get_WhenInstancePresent_ShouldReturnInstance()
+    {
+        var optional = Optional<int>.Of(() => 7);
+        var value = optional.Get();
+        Assert.That(value, Is.EqualTo(7));
+    }
+
+    [Test]
+    public void OrElse_WhenCallbackReturns_ShouldReturn()
+    {
+        var optional = Optional<int>.Of(() => throw new ArithmeticException());
+        var value = optional.OrElse(() => 7);
+        Assert.That(value, Is.EqualTo(7));
+    }
+
+    [Test]
+    public void OrElse_WhenCallbackThrows_ShouldThrow()
+    {
+        var optional = Optional<int>.Of(() => throw new ArithmeticException());
+        Assert.Throws<InvalidDataException>(() =>
+        {
+            optional.OrElse(() => throw new InvalidDataException());
+        });
+    }
+    
+}

--- a/SlottyMedia.Tests/Viewmodel/MainLayoutVmImplTest.cs
+++ b/SlottyMedia.Tests/Viewmodel/MainLayoutVmImplTest.cs
@@ -5,6 +5,7 @@ using SlottyMedia.Backend.Services.Interfaces;
 using SlottyMedia.Backend.ViewModel;
 using SlottyMedia.Database;
 using SlottyMedia.Database.Daos;
+using SlottyMedia.Utils;
 using Supabase.Gotrue;
 using Client = Supabase.Client;
 
@@ -72,8 +73,9 @@ public class MainLayoutVmImplTest
     {
         _authService.Setup(service => service.GetCurrentSession())
             .Returns(new Session { User = new User { Email = "test@test.de" } });
-        _dbActions.Setup(service => service.GetEntityByField<UserDao>("email", "test@test.de")).ReturnsAsync(new UserDao
-            { UserId = null, UserName = null, Description = null, Email = null });
+        _dbActions.Setup(service => service.GetEntityByField<UserDao>("email", "test@test.de")).ReturnsAsync(
+            Optional<UserDao>.Of(new UserDao { UserId = null, UserName = null, Description = null, Email = null })
+            );
         Assert.ThatAsync(async () => await _vm.SetUserInfo(), Is.Null);
         _authService.VerifyAll();
         _authService.VerifyNoOtherCalls();
@@ -89,7 +91,7 @@ public class MainLayoutVmImplTest
             UserId = Guid.NewGuid(), UserName = "Test", Description = "TestDesc", Email = "test@test.de",
             ProfilePic = "123"
         };
-        _dbActions.Setup(service => service.GetEntityByField<UserDao>("email", "test@test.de")).ReturnsAsync(userDao);
+        _dbActions.Setup(service => service.GetEntityByField<UserDao>("email", "test@test.de")).ReturnsAsync(Optional<UserDao>.Of(userDao));
         Assert.MultipleAsync(async () =>
             {
                 var serviceCall = await _vm.SetUserInfo();

--- a/SlottyMedia.Utils/.config/dotnet-tools.json
+++ b/SlottyMedia.Utils/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "xmldoc2markdown": {
+      "version": "4.0.0",
+      "commands": [
+        "xmldoc2md"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/SlottyMedia.Utils/Optional.cs
+++ b/SlottyMedia.Utils/Optional.cs
@@ -9,27 +9,30 @@ namespace SlottyMedia.Utils;
 ///     OrElseNull() will return null if no value is present and OrElseThrow() throws an exception instead.
 ///     <br /> <br />
 ///     This class can be instantiated with the static Of() and OfAsync() methods.
+///     <br /><br />
+///     <b>NOTE: </b> This class is intended for reference types only! If used with value types, this class may
+///     give unexpected results.
 /// </summary>
 /// <example>
 ///     <code>
 ///     // simply retrieve the contained value
-///     var opt = Optional&lt;int&gt;.Of(() => 7);
-///     var result = opt.Get(); // = 7
+///     var opt = Optional&lt;string&gt;.Of("Hello");
+///     var result = opt.Get(); // = "Hello"
 ///     <br />
 ///     // return null if an exception is thrown
-///     var opt = Optional&lt;int&gt;.Of(() => throw new ArithmeticException());
+///     var opt = Optional&lt;string&gt;.Of(() => throw new ArithmeticException());
 ///     var result = opt.OrElseNull(); // = null
 ///     <br />
 ///     // throw exception if no value is present
-///     var opt = Optional&lt;int&gt;.Of(() => throw new ArithmeticException());
+///     var opt = Optional&lt;string&gt;.Of(() => throw new ArithmeticException());
 ///     var result = opt.OrElseThrow();
 ///     <br />
 ///     // get value asynchronously
-///     var opt = await Optional&lt;int&gt;.OfAsync(async () => await someAsyncCalculation());
+///     var opt = await Optional&lt;string&gt;.OfAsync(async () => await someAsyncCalculation());
 ///     var result = opt.OrElseNull();
 ///     </code>
 /// </example>
-/// <typeparam name="T">The type of the optional value</typeparam>
+/// <typeparam name="T">The type of the optional value. Should be a reference type!</typeparam>
 public class Optional<T>
 {
     private T? _instance;

--- a/SlottyMedia.Utils/Optional.cs
+++ b/SlottyMedia.Utils/Optional.cs
@@ -38,6 +38,15 @@ public class Optional<T>
     private Optional() {}
 
     /// <summary>
+    /// Creates an empty optional value.
+    /// </summary>
+    /// <returns>The optional value</returns>
+    public static Optional<T> Empty()
+    {
+        return new Optional<T>();
+    }
+
+    /// <summary>
     /// Creates an optional value form the given instance.
     /// </summary>
     /// <param name="instance">The value to encapsulate</param>
@@ -109,6 +118,19 @@ public class Optional<T>
             throw new InvalidOperationException("Could not retrieve optional data because an exception was thrown during callback invocation", _innerException);
         if (_instance is null)
             throw new NullReferenceException("Could not retrieve optional data because data was null");
+        return _instance!;
+    }
+
+    /// <summary>
+    /// Attempts to retrieve the value contained by this object. If no value was present, returns the supplied
+    /// instance instead.
+    /// </summary>
+    /// <param name="instance">The instance to return if this object was empty</param>
+    /// <returns>The value</returns>
+    public T OrElse(T instance)
+    {
+        if (_innerException is not null || _instance is not null)
+            return instance;
         return _instance!;
     }
 

--- a/SlottyMedia.Utils/Optional.cs
+++ b/SlottyMedia.Utils/Optional.cs
@@ -120,7 +120,9 @@ public class Optional<T>
     /// <returns>The value</returns>
     public T? OrElse(Func<T?> function)
     {
-        return _instance ?? function.Invoke();
+        if (_innerException is not null || _instance is not null)
+            return function.Invoke();
+        return _instance;
     }
 
     /// <summary>
@@ -135,7 +137,9 @@ public class Optional<T>
     /// <returns>The value</returns>
     public T? OrElse(Func<Exception?, T?> function)
     {
-        return _instance ?? function.Invoke(_innerException);
+        if (_innerException is not null || _instance is not null)
+            return function.Invoke(_innerException);
+        return _instance;
     }
     
     /// <summary>
@@ -146,7 +150,9 @@ public class Optional<T>
     /// <returns>The value</returns>
     public async Task<T?> OrElseAsync(Func<Task<T?>> function)
     {
-        return _instance ?? await function.Invoke();
+        if (_innerException is not null || _instance is not null)
+            return await function.Invoke();
+        return _instance;
     }
 
     /// <summary>
@@ -161,7 +167,9 @@ public class Optional<T>
     /// <returns>The value</returns>
     public async Task<T?> OrElseAsync(Func<Exception?, Task<T?>> function)
     {
-        return _instance ?? await function.Invoke(_innerException);
+        if (_innerException is not null || _instance is not null)
+            return await function.Invoke(_innerException);
+        return _instance;
     }
 
     /// <summary>

--- a/SlottyMedia.Utils/Optional.cs
+++ b/SlottyMedia.Utils/Optional.cs
@@ -1,4 +1,4 @@
-namespace SlottyMedia.Backend.Util;
+namespace SlottyMedia.Utils;
 
 
 /// <summary>

--- a/SlottyMedia.Utils/Optional.cs
+++ b/SlottyMedia.Utils/Optional.cs
@@ -38,6 +38,19 @@ public class Optional<T>
     private Optional() {}
 
     /// <summary>
+    /// Creates an optional value form the given instance.
+    /// </summary>
+    /// <param name="instance">The value to encapsulate</param>
+    /// <returns>The optional value</returns>
+    public static Optional<T> Of(T instance)
+    {
+        return new Optional<T>
+        {
+            _instance = instance
+        };
+    }
+
+    /// <summary>
     /// Creates an optional value from the given function.
     /// </summary>
     /// <param name="function">The function that evaluates the optional value</param>

--- a/SlottyMedia.Utils/SlottyMedia.Utils.csproj
+++ b/SlottyMedia.Utils/SlottyMedia.Utils.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    </PropertyGroup>
+
+</Project>

--- a/SlottyMedia.Utils/SlottyMedia.Utils.csproj
+++ b/SlottyMedia.Utils/SlottyMedia.Utils.csproj
@@ -8,4 +8,8 @@
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     </PropertyGroup>
 
+    <Target Name="GenerateDocumentation" AfterTargets="Build" Condition="'$(GITHUB_ACTIONS)' != 'true'">
+        <Exec Command="dotnet tool run xmldoc2md ./bin/Debug/net8.0/SlottyMedia.Utils.dll ../slottymedia-docs/docs/code/SlottyMedia.Utils"/>
+    </Target>
+
 </Project>

--- a/SlottyMedia.sln
+++ b/SlottyMedia.sln
@@ -16,6 +16,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SlottyMedia.DatabaseSeeding
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SlottyMedia.LoggingProvider", "SlottyMedia.LoggingProvider\SlottyMedia.LoggingProvider.csproj", "{F13C21E8-1D7B-4FC3-8EFF-E54EA0A74E5D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SlottyMedia.Utils", "SlottyMedia.Utils\SlottyMedia.Utils.csproj", "{3C19C671-8507-4648-8D64-5E37E52B4BB0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -48,5 +50,9 @@ Global
 		{F13C21E8-1D7B-4FC3-8EFF-E54EA0A74E5D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F13C21E8-1D7B-4FC3-8EFF-E54EA0A74E5D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F13C21E8-1D7B-4FC3-8EFF-E54EA0A74E5D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3C19C671-8507-4648-8D64-5E37E52B4BB0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3C19C671-8507-4648-8D64-5E37E52B4BB0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3C19C671-8507-4648-8D64-5E37E52B4BB0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3C19C671-8507-4648-8D64-5E37E52B4BB0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/SlottyMedia/Backend/Services/SignupServiceImpl.cs
+++ b/SlottyMedia/Backend/Services/SignupServiceImpl.cs
@@ -72,7 +72,7 @@ public class SignupServiceImpl : ISignupService
         if (session == null)
             throw new InvalidOperationException(
                 "An unknown error occured in the Supabase client while attempting to perform a signup.");
-        var userRole = await _databaseActions.GetEntityByField<RoleDao>("role", "User");
+        var userRole = (await _databaseActions.GetEntityByField<RoleDao>("role", "User")).OrElseThrow();
         var roleId = userRole.RoleId.HasValue
             ? userRole.RoleId.Value
             : throw new NullReferenceException("RoleId not found!");

--- a/SlottyMedia/Backend/Services/UserService.cs
+++ b/SlottyMedia/Backend/Services/UserService.cs
@@ -113,7 +113,7 @@ public class UserService : IUserService
         try
         {
             Logger.LogInfo($"Fetching user with ID {userId}");
-            var user = await _databaseActions.GetEntityByField<UserDao>("userID", userId.ToString());
+            var user = (await _databaseActions.GetEntityByField<UserDao>("userID", userId.ToString())).OrElseThrow();
             return new UserDto().Mapper(user);
         }
         catch (DatabaseMissingItemException ex)
@@ -211,12 +211,12 @@ public class UserService : IUserService
             else if (username is not null)
             {
                 Logger.LogInfo($"Attempting to retrieve user by username: {username}");
-                user = await _databaseActions.GetEntityByField<UserDao>("userName", username);
+                user = (await _databaseActions.GetEntityByField<UserDao>("userName", username)).OrElseThrow();
             }
             else if (email is not null)
             {
                 Logger.LogInfo($"Attempting to retrieve user by email: {email}");
-                user = await _databaseActions.GetEntityByField<UserDao>("email", email);
+                user = (await _databaseActions.GetEntityByField<UserDao>("email", email)).OrElseThrow();
             }
 
             if (user != null)
@@ -290,7 +290,7 @@ public class UserService : IUserService
             Logger.LogInfo($"Fetching user with ID {userId} and recent forums {recentForums}");
             var result = await _databaseActions.GetEntitieWithSelectorById<UserDao>(
                 x => new object[] { x.UserId!, x.UserName!, x.Description!, x.CreatedAt }, "userID", userId.ToString());
-            var user = new UserDto().Mapper(result);
+            var user = new UserDto().Mapper(result.OrElseThrow());
 
             Logger.LogInfo($"Fetching recent forums for user with ID {userId}");
             user.RecentForums = await _postService.GetPostsFromForum(userId, 0, recentForums);
@@ -362,7 +362,7 @@ public class UserService : IUserService
         {
             Logger.LogInfo($"Fetching user with ID {userId}");
             var user = await _databaseActions.GetEntityByField<UserDao>("userID", userId.ToString());
-            return user;
+            return user.OrElseThrow();
         }
         catch (DatabaseMissingItemException ex)
         {

--- a/SlottyMedia/Backend/Util/Optional.cs
+++ b/SlottyMedia/Backend/Util/Optional.cs
@@ -1,0 +1,196 @@
+namespace SlottyMedia.Backend.Util;
+
+
+/// <summary>
+///     A container object which may or may not contain a certain value. If a value is present, IsPresent() will
+///     return true and Get() will return the value.
+///     <br /><br />
+///     There are additional utility methods to manipulate the value with respects to its presence. For example,
+///     OrElseNull() will return null if no value is present and OrElseThrow() throws an exception instead.
+///     <br /> <br />
+///     This class can be instantiated with the static Of() and OfAsync() methods.
+/// </summary>
+/// <example>
+///     <code>
+///     // simply retrieve the contained value
+///     var opt = Optional&lt;int&gt;.Of(() => 7);
+///     var result = opt.Get(); // = 7
+///     <br />
+///     // return null if an exception is thrown
+///     var opt = Optional&lt;int&gt;.Of(() => throw new ArithmeticException());
+///     var result = opt.OrElseNull(); // = null
+///     <br />
+///     // throw exception if no value is present
+///     var opt = Optional&lt;int&gt;.Of(() => throw new ArithmeticException());
+///     var result = opt.OrElseThrow();
+///     <br />
+///     // get value asynchronously
+///     var opt = await Optional&lt;int&gt;.OfAsync(async () => await someAsyncCalculation());
+///     var result = opt.OrElseNull();
+///     </code>
+/// </example>
+/// <typeparam name="T">The type of the optional value</typeparam>
+public class Optional<T>
+{
+    private T? _instance;
+    private Exception? _innerException;
+    
+    private Optional() {}
+
+    /// <summary>
+    /// Creates an optional value from the given function.
+    /// </summary>
+    /// <param name="function">The function that evaluates the optional value</param>
+    /// <returns>The optional value</returns>
+    public static Optional<T> Of(Func<T> function)
+    {
+        var result = new Optional<T>();
+        try
+        {
+            result._instance = function.Invoke();
+        }
+        catch (Exception e)
+        {
+            result._innerException = e;
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Creates an optional value from the given asynchronous function.
+    /// </summary>
+    /// <param name="function">The function that evaluates the optional value</param>
+    /// <returns>A Task that contains the optional value</returns>
+    public static async Task<Optional<T>> OfAsync(Func<Task<T>> function)
+    {
+        var result = new Optional<T>();
+        try
+        {
+            result._instance = await function.Invoke();
+        }
+        catch (Exception e)
+        {
+            result._innerException = e;
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Evaluates whether a value is present.
+    /// </summary>
+    /// <returns>Whether a value is present</returns>
+    public bool IsPresent()
+    {
+        return _innerException is null && _instance is not null;
+    }
+
+    /// <summary>
+    /// Retrieves the value contained in this object.
+    /// </summary>
+    /// <returns>The value</returns>
+    /// <exception cref="InvalidOperationException">If an exception was thrown while evaluating the value</exception>
+    /// <exception cref="NullReferenceException">If no exception was thrown but no value was present nonetheless</exception>
+    public T Get()
+    {
+        if (_innerException is not null)
+            throw new InvalidOperationException("Could not retrieve optional data because an exception was thrown during callback invocation", _innerException);
+        if (_instance is null)
+            throw new NullReferenceException("Could not retrieve optional data because data was null");
+        return _instance!;
+    }
+
+    /// <summary>
+    /// Attempts to retrieve the value contained by this object. If no value was present, invokes the given
+    /// callback instead and returns its result.
+    /// </summary>
+    /// <param name="function">A callback that is invoked when no value is present</param>
+    /// <returns>The value</returns>
+    public T? OrElse(Func<T?> function)
+    {
+        return _instance ?? function.Invoke();
+    }
+
+    /// <summary>
+    /// Attempts to retrieve the value contained by this object. If no value was present, invokes the given
+    /// callback instead and returns its result.
+    /// </summary>
+    /// <param name="function">
+    /// A callback that is invoked when no value is present.
+    /// Its parameter is an exception that was thrown during the evaluation
+    /// or null if no exception was thrown.
+    /// </param>
+    /// <returns>The value</returns>
+    public T? OrElse(Func<Exception?, T?> function)
+    {
+        return _instance ?? function.Invoke(_innerException);
+    }
+    
+    /// <summary>
+    /// Attempts to retrieve the value contained by this object. If no value was present, asynchronously invokes
+    /// the given callback instead and returns a Task that contains its result.
+    /// </summary>
+    /// <param name="function">A callback that is invoked when no value is present</param>
+    /// <returns>The value</returns>
+    public async Task<T?> OrElseAsync(Func<Task<T?>> function)
+    {
+        return _instance ?? await function.Invoke();
+    }
+
+    /// <summary>
+    /// Attempts to retrieve the value contained by this object. If no value was present, asynchronously invokes the given
+    /// callback instead and returns a Task that contains its result.
+    /// </summary>
+    /// <param name="function">
+    /// A callback that is invoked when no value is present.
+    /// Its parameter is an exception that was thrown during the evaluation
+    /// or null if no exception was thrown.
+    /// </param>
+    /// <returns>The value</returns>
+    public async Task<T?> OrElseAsync(Func<Exception?, Task<T?>> function)
+    {
+        return _instance ?? await function.Invoke(_innerException);
+    }
+
+    /// <summary>
+    /// Attempts to retrieve the value contained by this object. Returns null of no value was present.
+    /// </summary>
+    /// <returns>The value or null if not present</returns>
+    public T? OrElseNull()
+    {
+        return _instance;
+    }
+
+    /// <summary>
+    /// Attempts to retrieve the value contained by this object. Throws an exception if no value was present.
+    /// </summary>
+    /// <returns>The value</returns>
+    /// <exception cref="Exception">An inner exception that was raised while evaluating the value</exception>
+    /// <exception cref="NullReferenceException">If no exception was raised but the value was null nonetheless</exception>
+    public T OrElseThrow()
+    {
+        if (_innerException is not null)
+            throw _innerException;
+        if (_instance is null)
+            throw new NullReferenceException("Could not retrieve optional data because data was null");
+        return _instance!;
+    }
+
+    /// <summary>
+    /// Attempts to retrieve the value contained by this object. Throws an exception if no value was present.
+    /// </summary>
+    /// <param name="callback">
+    /// A callback function that is invoked when an exception was raised while evaluating the value.
+    /// The supplied parameter is the exception.
+    /// </param>
+    /// <returns>The value</returns>
+    /// <exception cref="Exception">An inner exception that was raised while evaluating the value</exception>
+    /// <exception cref="NullReferenceException">If no exception was raised but the value was null nonetheless</exception>
+    public T OrElseThrow(Func<Exception, Exception> callback)
+    {
+        if (_innerException is not null)
+            throw callback.Invoke(_innerException);
+        if (_instance is null)
+            throw new NullReferenceException("Could not retrieve optional data because data was null");
+        return _instance!;
+    }
+}

--- a/SlottyMedia/Backend/ViewModel/MainLayoutVmImpl.cs
+++ b/SlottyMedia/Backend/ViewModel/MainLayoutVmImpl.cs
@@ -64,7 +64,7 @@ public class MainLayoutVmImpl : IMainLayoutVm
         var currentSession = _authService.GetCurrentSession();
         if (currentSession != null)
         {
-            var userDao = await _databaseActions.GetEntityByField<UserDao>("email", currentSession.User!.Email!);
+            var userDao = (await _databaseActions.GetEntityByField<UserDao>("email", currentSession.User!.Email!)).OrElseThrow();
             if (userDao is { UserId: null, UserName: null, Description: null, Email: null })
             {
                 _logger.LogError(

--- a/SlottyMedia/Components/Partial/DescriptionContainer.razor
+++ b/SlottyMedia/Components/Partial/DescriptionContainer.razor
@@ -37,7 +37,7 @@ else
         if (emailOfUser != null)
         {
             ShowDescriptionText = !ShowDescriptionText;
-            var userDao = await DatabaseActions.GetEntityByField<UserDao>("email", emailOfUser);
+            var userDao = (await DatabaseActions.GetEntityByField<UserDao>("email", emailOfUser)).OrElseThrow();
             userDao.Description = DescriptionText;
             await DatabaseActions.Update(userDao);
         }

--- a/slottymedia-docs/docs/code/SlottyMedia.Database/slottymedia.database.databaseactions.md
+++ b/slottymedia-docs/docs/code/SlottyMedia.Database/slottymedia.database.databaseactions.md
@@ -128,7 +128,7 @@ Thrown when a network error, argument null, invalid operation, timeout, task
 Retrieves an entity from the database by a specific field and value.
 
 ```csharp
-public Task<T> GetEntityByField<T>(string field, string value)
+public Task<Optional<T>> GetEntityByField<T>(string field, string value)
 ```
 
 #### Type Parameters
@@ -146,7 +146,7 @@ The value to filter by.
 
 #### Returns
 
-Task&lt;T&gt;<br>
+Task&lt;Optional&lt;T&gt;&gt;<br>
 The retrieved entity.
 
 #### Exceptions
@@ -163,7 +163,7 @@ Thrown when a network error, argument null, invalid operation, timeout, task
 Retrieves an entity from the database by a specific field and value with a selector.
 
 ```csharp
-public Task<T> GetEntitieWithSelectorById<T>(Expression<Func<T, Object[]>> selector, string field, string value)
+public Task<Optional<T>> GetEntitieWithSelectorById<T>(Expression<Func<T, Object[]>> selector, string field, string value)
 ```
 
 #### Type Parameters
@@ -184,7 +184,7 @@ The value to filter by.
 
 #### Returns
 
-Task&lt;T&gt;<br>
+Task&lt;Optional&lt;T&gt;&gt;<br>
 The retrieved entity.
 
 #### Exceptions

--- a/slottymedia-docs/docs/code/SlottyMedia.Database/slottymedia.database.idatabaseactions.md
+++ b/slottymedia-docs/docs/code/SlottyMedia.Database/slottymedia.database.idatabaseactions.md
@@ -84,7 +84,7 @@ Returns true if the operation was successful.
 Returns an entity from the database based on the given field and value.
 
 ```csharp
-Task<T> GetEntityByField<T>(string field, string value)
+Task<Optional<T>> GetEntityByField<T>(string field, string value)
 ```
 
 #### Type Parameters
@@ -102,7 +102,7 @@ The value to search for.
 
 #### Returns
 
-Task&lt;T&gt;<br>
+Task&lt;Optional&lt;T&gt;&gt;<br>
 Returns the entity from the database.
 
 ### **GetEntitieWithSelectorById&lt;T&gt;(Expression&lt;Func&lt;T, Object[]&gt;&gt;, String, String)**
@@ -110,7 +110,7 @@ Returns the entity from the database.
 Returns an entity with a selector from the database based on the given field and value.
 
 ```csharp
-Task<T> GetEntitieWithSelectorById<T>(Expression<Func<T, Object[]>> selector, string field, string value)
+Task<Optional<T>> GetEntitieWithSelectorById<T>(Expression<Func<T, Object[]>> selector, string field, string value)
 ```
 
 #### Type Parameters
@@ -131,7 +131,7 @@ The value to search for.
 
 #### Returns
 
-Task&lt;T&gt;<br>
+Task&lt;Optional&lt;T&gt;&gt;<br>
 Returns the entity from the database.
 
 ### **GetEntitiesWithSelectorById&lt;T&gt;(Expression&lt;Func&lt;T, Object[]&gt;&gt;, String, String, Int32, Int32, ValueTuple`3[])**

--- a/slottymedia-docs/docs/code/SlottyMedia.Tests/index.md
+++ b/slottymedia-docs/docs/code/SlottyMedia.Tests/index.md
@@ -44,6 +44,10 @@
 
 [UserServiceTests](./slottymedia.tests.servicetests.userservicetests.md)
 
+## SlottyMedia.Tests.UtilTests
+
+[OptionalTests](./slottymedia.tests.utiltests.optionaltests.md)
+
 ## SlottyMedia.Tests.Viewmodel
 
 [MainLayoutVmImplTest](./slottymedia.tests.viewmodel.mainlayoutvmimpltest.md)

--- a/slottymedia-docs/docs/code/SlottyMedia.Tests/slottymedia.tests.databasetests.databaseactiontests.md
+++ b/slottymedia-docs/docs/code/SlottyMedia.Tests/slottymedia.tests.databasetests.databaseactiontests.md
@@ -149,8 +149,12 @@ public Task GetEntityByField()
 Tests the GetEntityByField method of DatabaseActions for failure.
 
 ```csharp
-public void GetEntityByField_Failure()
+public Task GetEntityByField_Failure()
 ```
+
+#### Returns
+
+[Task](https://docs.microsoft.com/en-us/dotnet/api/system.threading.tasks.task)<br>
 
 ### **GetEntitieWithSelectorById()**
 
@@ -169,8 +173,12 @@ public Task GetEntitieWithSelectorById()
 Tests the GetEntitieWithSelectorById method of DatabaseActions for failure.
 
 ```csharp
-public void GetEntitieWithSelectorById_Failure()
+public Task GetEntitieWithSelectorById_Failure()
 ```
+
+#### Returns
+
+[Task](https://docs.microsoft.com/en-us/dotnet/api/system.threading.tasks.task)<br>
 
 ### **GetEntitiesWithSelectorById()**
 

--- a/slottymedia-docs/docs/code/SlottyMedia.Tests/slottymedia.tests.servicetests.userservicetests.md
+++ b/slottymedia-docs/docs/code/SlottyMedia.Tests/slottymedia.tests.servicetests.userservicetests.md
@@ -285,3 +285,13 @@ public void GetCountOfUserFriends_ThrowsUserGeneralException_OnUnexpectedExcepti
 
 This test ensures that the GetCountOfUserFriends method throws a UserGeneralException when an unexpected exception
  occurs.
+
+### **GetCountOfUserSpaces()**
+
+```csharp
+public Task GetCountOfUserSpaces()
+```
+
+#### Returns
+
+[Task](https://docs.microsoft.com/en-us/dotnet/api/system.threading.tasks.task)<br>

--- a/slottymedia-docs/docs/code/SlottyMedia.Tests/slottymedia.tests.utiltests.optionaltests.md
+++ b/slottymedia-docs/docs/code/SlottyMedia.Tests/slottymedia.tests.utiltests.optionaltests.md
@@ -47,3 +47,33 @@ public void OrElse_WhenCallbackReturns_ShouldReturn()
 ```csharp
 public void OrElse_WhenCallbackThrows_ShouldThrow()
 ```
+
+### **OrElseNull_WhenInstanceNotNull_ShouldReturnInstance()**
+
+```csharp
+public void OrElseNull_WhenInstanceNotNull_ShouldReturnInstance()
+```
+
+### **OrElseNull_WhenInstanceNull_ShouldReturnNull()**
+
+```csharp
+public void OrElseNull_WhenInstanceNull_ShouldReturnNull()
+```
+
+### **OrElseThrow_WhenEvaluationThrows_ShouldRethrow()**
+
+```csharp
+public void OrElseThrow_WhenEvaluationThrows_ShouldRethrow()
+```
+
+### **OrElseThrow_WhenEmpty_ShouldThrow()**
+
+```csharp
+public void OrElseThrow_WhenEmpty_ShouldThrow()
+```
+
+### **OrElseThrow_WhenInstancePresent_ShouldReturnInstance()**
+
+```csharp
+public void OrElseThrow_WhenInstancePresent_ShouldReturnInstance()
+```

--- a/slottymedia-docs/docs/code/SlottyMedia.Tests/slottymedia.tests.utiltests.optionaltests.md
+++ b/slottymedia-docs/docs/code/SlottyMedia.Tests/slottymedia.tests.utiltests.optionaltests.md
@@ -1,0 +1,49 @@
+# OptionalTests
+
+Namespace: SlottyMedia.Tests.UtilTests
+
+```csharp
+public class OptionalTests
+```
+
+Inheritance [Object](https://docs.microsoft.com/en-us/dotnet/api/system.object) → [OptionalTests](./slottymedia.tests.utiltests.optionaltests.md)
+
+## Constructors
+
+### **OptionalTests()**
+
+```csharp
+public OptionalTests()
+```
+
+## Methods
+
+### **Get_WhenInnerException_ShouldThrow()**
+
+```csharp
+public void Get_WhenInnerException_ShouldThrow()
+```
+
+### **Get_WhenInstanceNull_ShouldThrow()**
+
+```csharp
+public void Get_WhenInstanceNull_ShouldThrow()
+```
+
+### **Get_WhenInstancePresent_ShouldReturnInstance()**
+
+```csharp
+public void Get_WhenInstancePresent_ShouldReturnInstance()
+```
+
+### **OrElse_WhenCallbackReturns_ShouldReturn()**
+
+```csharp
+public void OrElse_WhenCallbackReturns_ShouldReturn()
+```
+
+### **OrElse_WhenCallbackThrows_ShouldThrow()**
+
+```csharp
+public void OrElse_WhenCallbackThrows_ShouldThrow()
+```

--- a/slottymedia-docs/docs/code/SlottyMedia.Utils/index.md
+++ b/slottymedia-docs/docs/code/SlottyMedia.Utils/index.md
@@ -1,0 +1,5 @@
+# SlottyMedia.Utils
+
+## SlottyMedia.Utils
+
+[Optional&lt;T&gt;](./slottymedia.utils.optional-1.md)

--- a/slottymedia-docs/docs/code/SlottyMedia.Utils/slottymedia.utils.optional-1.md
+++ b/slottymedia-docs/docs/code/SlottyMedia.Utils/slottymedia.utils.optional-1.md
@@ -1,0 +1,287 @@
+# Optional&lt;T&gt;
+
+Namespace: SlottyMedia.Utils
+
+A container object which may or may not contain a certain value. If a value is present, IsPresent() will
+ return true and Get() will return the value.
+ <br><br>
+ There are additional utility methods to manipulate the value with respects to its presence. For example,
+ OrElseNull() will return null if no value is present and OrElseThrow() throws an exception instead.
+ <br><br>
+ This class can be instantiated with the static Of() and OfAsync() methods.
+ <br><br>NOTE:  This class is intended for reference types only! If used with value types, this class may
+ give unexpected results.
+
+```csharp
+public class Optional<T>
+```
+
+#### Type Parameters
+
+`T`<br>
+The type of the optional value. Should be a reference type!
+
+Inheritance [Object](https://docs.microsoft.com/en-us/dotnet/api/system.object) → [Optional&lt;T&gt;](./slottymedia.utils.optional-1.md)
+
+## Methods
+
+### **Empty()**
+
+Creates an empty optional value.
+
+```csharp
+public static Optional<T> Empty()
+```
+
+#### Returns
+
+[Optional&lt;T&gt;](./slottymedia.utils.optional-1.md)<br>
+The optional value
+
+### **Of(T)**
+
+Creates an optional value form the given instance.
+
+```csharp
+public static Optional<T> Of(T instance)
+```
+
+#### Parameters
+
+`instance` T<br>
+The value to encapsulate
+
+#### Returns
+
+[Optional&lt;T&gt;](./slottymedia.utils.optional-1.md)<br>
+The optional value
+
+### **Of(Func&lt;T&gt;)**
+
+Creates an optional value from the given function.
+
+```csharp
+public static Optional<T> Of(Func<T> function)
+```
+
+#### Parameters
+
+`function` Func&lt;T&gt;<br>
+The function that evaluates the optional value
+
+#### Returns
+
+[Optional&lt;T&gt;](./slottymedia.utils.optional-1.md)<br>
+The optional value
+
+### **OfAsync(Func&lt;Task&lt;T&gt;&gt;)**
+
+Creates an optional value from the given asynchronous function.
+
+```csharp
+public static Task<Optional<T>> OfAsync(Func<Task<T>> function)
+```
+
+#### Parameters
+
+`function` Func&lt;Task&lt;T&gt;&gt;<br>
+The function that evaluates the optional value
+
+#### Returns
+
+Task&lt;Optional&lt;T&gt;&gt;<br>
+A Task that contains the optional value
+
+### **IsPresent()**
+
+Evaluates whether a value is present.
+
+```csharp
+public bool IsPresent()
+```
+
+#### Returns
+
+[Boolean](https://docs.microsoft.com/en-us/dotnet/api/system.boolean)<br>
+Whether a value is present
+
+### **Get()**
+
+Retrieves the value contained in this object.
+
+```csharp
+public T Get()
+```
+
+#### Returns
+
+T<br>
+The value
+
+#### Exceptions
+
+[InvalidOperationException](https://docs.microsoft.com/en-us/dotnet/api/system.invalidoperationexception)<br>
+If an exception was thrown while evaluating the value
+
+[NullReferenceException](https://docs.microsoft.com/en-us/dotnet/api/system.nullreferenceexception)<br>
+If no exception was thrown but no value was present nonetheless
+
+### **OrElse(T)**
+
+Attempts to retrieve the value contained by this object. If no value was present, returns the supplied
+ instance instead.
+
+```csharp
+public T OrElse(T instance)
+```
+
+#### Parameters
+
+`instance` T<br>
+The instance to return if this object was empty
+
+#### Returns
+
+T<br>
+The value
+
+### **OrElse(Func&lt;T&gt;)**
+
+Attempts to retrieve the value contained by this object. If no value was present, invokes the given
+ callback instead and returns its result.
+
+```csharp
+public T OrElse(Func<T> function)
+```
+
+#### Parameters
+
+`function` Func&lt;T&gt;<br>
+A callback that is invoked when no value is present
+
+#### Returns
+
+T<br>
+The value
+
+### **OrElse(Func&lt;Exception, T&gt;)**
+
+Attempts to retrieve the value contained by this object. If no value was present, invokes the given
+ callback instead and returns its result.
+
+```csharp
+public T OrElse(Func<Exception, T> function)
+```
+
+#### Parameters
+
+`function` Func&lt;Exception, T&gt;<br>
+A callback that is invoked when no value is present.
+ Its parameter is an exception that was thrown during the evaluation
+ or null if no exception was thrown.
+
+#### Returns
+
+T<br>
+The value
+
+### **OrElseAsync(Func&lt;Task&lt;T&gt;&gt;)**
+
+Attempts to retrieve the value contained by this object. If no value was present, asynchronously invokes
+ the given callback instead and returns a Task that contains its result.
+
+```csharp
+public Task<T> OrElseAsync(Func<Task<T>> function)
+```
+
+#### Parameters
+
+`function` Func&lt;Task&lt;T&gt;&gt;<br>
+A callback that is invoked when no value is present
+
+#### Returns
+
+Task&lt;T&gt;<br>
+The value
+
+### **OrElseAsync(Func&lt;Exception, Task&lt;T&gt;&gt;)**
+
+Attempts to retrieve the value contained by this object. If no value was present, asynchronously invokes the given
+ callback instead and returns a Task that contains its result.
+
+```csharp
+public Task<T> OrElseAsync(Func<Exception, Task<T>> function)
+```
+
+#### Parameters
+
+`function` Func&lt;Exception, Task&lt;T&gt;&gt;<br>
+A callback that is invoked when no value is present.
+ Its parameter is an exception that was thrown during the evaluation
+ or null if no exception was thrown.
+
+#### Returns
+
+Task&lt;T&gt;<br>
+The value
+
+### **OrElseNull()**
+
+Attempts to retrieve the value contained by this object. Returns null of no value was present.
+
+```csharp
+public T OrElseNull()
+```
+
+#### Returns
+
+T<br>
+The value or null if not present
+
+### **OrElseThrow()**
+
+Attempts to retrieve the value contained by this object. Throws an exception if no value was present.
+
+```csharp
+public T OrElseThrow()
+```
+
+#### Returns
+
+T<br>
+The value
+
+#### Exceptions
+
+[Exception](https://docs.microsoft.com/en-us/dotnet/api/system.exception)<br>
+An inner exception that was raised while evaluating the value
+
+[NullReferenceException](https://docs.microsoft.com/en-us/dotnet/api/system.nullreferenceexception)<br>
+If no exception was raised but the value was null nonetheless
+
+### **OrElseThrow(Func&lt;Exception, Exception&gt;)**
+
+Attempts to retrieve the value contained by this object. Throws an exception if no value was present.
+
+```csharp
+public T OrElseThrow(Func<Exception, Exception> callback)
+```
+
+#### Parameters
+
+`callback` [Func&lt;Exception, Exception&gt;](https://docs.microsoft.com/en-us/dotnet/api/system.func-2)<br>
+A callback function that is invoked when an exception was raised while evaluating the value.
+ The supplied parameter is the exception.
+
+#### Returns
+
+T<br>
+The value
+
+#### Exceptions
+
+[Exception](https://docs.microsoft.com/en-us/dotnet/api/system.exception)<br>
+An inner exception that was raised while evaluating the value
+
+[NullReferenceException](https://docs.microsoft.com/en-us/dotnet/api/system.nullreferenceexception)<br>
+If no exception was raised but the value was null nonetheless

--- a/slottymedia-docs/docs/code/SlottyMedia/slottymedia.backend.util.optional-1.md
+++ b/slottymedia-docs/docs/code/SlottyMedia/slottymedia.backend.util.optional-1.md
@@ -1,0 +1,171 @@
+# Optional&lt;T&gt;
+
+Namespace: SlottyMedia.Backend.Util
+
+```csharp
+public class Optional<T>
+```
+
+#### Type Parameters
+
+`T`<br>
+
+Inheritance [Object](https://docs.microsoft.com/en-us/dotnet/api/system.object) → [Optional&lt;T&gt;](./slottymedia.backend.util.optional-1.md)
+
+## Methods
+
+### **Of(Func&lt;T&gt;)**
+
+```csharp
+public static Optional<T> Of(Func<T> function)
+```
+
+#### Parameters
+
+`function` Func&lt;T&gt;<br>
+
+#### Returns
+
+[Optional&lt;T&gt;](./slottymedia.backend.util.optional-1.md)<br>
+
+### **OfAsync(Func&lt;Task&lt;T&gt;&gt;)**
+
+```csharp
+public static Task<Optional<T>> OfAsync(Func<Task<T>> function)
+```
+
+#### Parameters
+
+`function` Func&lt;Task&lt;T&gt;&gt;<br>
+
+#### Returns
+
+Task&lt;Optional&lt;T&gt;&gt;<br>
+
+### **Get()**
+
+```csharp
+public T Get()
+```
+
+#### Returns
+
+T<br>
+
+### **OrElse(Func&lt;T&gt;)**
+
+```csharp
+public T OrElse(Func<T> function)
+```
+
+#### Parameters
+
+`function` Func&lt;T&gt;<br>
+
+#### Returns
+
+T<br>
+
+### **OrElse(Func&lt;T, T&gt;)**
+
+```csharp
+public T OrElse(Func<T, T> function)
+```
+
+#### Parameters
+
+`function` Func&lt;T, T&gt;<br>
+
+#### Returns
+
+T<br>
+
+### **OrElse(Func&lt;T, Exception, T&gt;)**
+
+```csharp
+public T OrElse(Func<T, Exception, T> function)
+```
+
+#### Parameters
+
+`function` Func&lt;T, Exception, T&gt;<br>
+
+#### Returns
+
+T<br>
+
+### **OrElseAsync(Func&lt;Task&lt;T&gt;&gt;)**
+
+```csharp
+public Task<T> OrElseAsync(Func<Task<T>> function)
+```
+
+#### Parameters
+
+`function` Func&lt;Task&lt;T&gt;&gt;<br>
+
+#### Returns
+
+Task&lt;T&gt;<br>
+
+### **OrElseAsync(Func&lt;T, Task&lt;T&gt;&gt;)**
+
+```csharp
+public Task<T> OrElseAsync(Func<T, Task<T>> function)
+```
+
+#### Parameters
+
+`function` Func&lt;T, Task&lt;T&gt;&gt;<br>
+
+#### Returns
+
+Task&lt;T&gt;<br>
+
+### **OrElseAsync(Func&lt;T, Exception, Task&lt;T&gt;&gt;)**
+
+```csharp
+public Task<T> OrElseAsync(Func<T, Exception, Task<T>> function)
+```
+
+#### Parameters
+
+`function` Func&lt;T, Exception, Task&lt;T&gt;&gt;<br>
+
+#### Returns
+
+Task&lt;T&gt;<br>
+
+### **OrElseNull()**
+
+```csharp
+public T OrElseNull()
+```
+
+#### Returns
+
+T<br>
+
+### **OrElseThrow()**
+
+```csharp
+public T OrElseThrow()
+```
+
+#### Returns
+
+T<br>
+
+### **OrElseThrow(Func&lt;Exception, Exception&gt;)**
+
+```csharp
+public T OrElseThrow(Func<Exception, Exception> callback)
+```
+
+#### Parameters
+
+`callback` [Func&lt;Exception, Exception&gt;](https://docs.microsoft.com/en-us/dotnet/api/system.func-2)<br>
+
+#### Returns
+
+T<br>

--- a/slottymedia-docs/mkdocs.yml
+++ b/slottymedia-docs/mkdocs.yml
@@ -13,6 +13,7 @@ nav:
     - Database : code/SlottyMedia.Database/index.md
     - Seeding: code/SlottyMedia.DatabaseSeeding/index.md
     - Logging: code/SlottyMedia.LoggingProvider/index.md
+    - Options: code/SlottyMedia.Utils/index.md
     - Tests: code/SlottyMedia.Tests/index.md
   - Exception Guidelines: exceptions.md
   - Logging Guidelines : logging.md


### PR DESCRIPTION
In order to better handle values of functions which may or may not return I have created a container class `Optional<T>` which wraps some value of type `T` and lets us handle it individually. This feature does not provide any new functionalities, but adds some syntactic sugar which can speed up development and make code clearer. This class is very similar to [Java's Optional API](https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html).

For example, the following code block:
```csharp
MyDto? dto = null;
try
{
    // this might throw an exception and must be handled with try-catch
    dto = await _myService.DoSomething();
}
catch
{
    dto = null;
}
```
can now be simplified to this:
```csharp
var dto = (await _myService.DoSomething()).OrElseNull();
```
or, in case we want to immediately re-throw an exception if one occurs:
```csharp
var dto = (await _myService.DoSomething()).OrElseThrow();
```
I have also taken the liberty to implement this functionality in our codebase by adding it as the return type of two methods of `IDatabaseActions`.